### PR TITLE
Added Biopython version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(	name = 'GRAViTy',
 	],
 	#dependency_links = ['http://github.com/user/repo/tarball/master#egg = package-1.0'],
 	install_requires = [
-		'Biopython',
+		'Biopython<=1.76',
 		'numpy',
 		'ete3',
 		'matplotlib',


### PR DESCRIPTION
By default, pip looks for the latest version of Biopython. Unfortunately, only versions up to 1.76 support python 2; more recents version cause an error when running `sudo pip2 install .`.
For this reason I specified the biopython version as 1.76 or lower.